### PR TITLE
Add facility to take in new port for Docker container via cli env va…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:12.19.0-buster-slim
 RUN mkdir -p /opt/app
 WORKDIR /opt/app
-ENV PORT=5020
 RUN set -x \
   && addgroup --system --gid 101 app \
   && adduser --system --disabled-login --ingroup app --gecos "app user" --shell /bin/false --uid 101 app
@@ -9,5 +8,5 @@ COPY ./server .
 RUN chown -R app:app /opt/app
 USER app
 RUN npm install
-EXPOSE 5020
+EXPOSE 5000
 CMD [ "npm", "run", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:12.19.0-buster-slim
+RUN mkdir -p /opt/app
+WORKDIR /opt/app
+ENV PORT=5020
+RUN set -x \
+  && addgroup --system --gid 101 app \
+  && adduser --system --disabled-login --ingroup app --gecos "app user" --shell /bin/false --uid 101 app
+COPY ./server .
+RUN chown -R app:app /opt/app
+USER app
+RUN npm install
+EXPOSE 5020
+CMD [ "npm", "run", "start" ]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Backend code for the Task Manager application
 
 ## Available Scripts
+
 From the root of the project:
 
 ```
@@ -11,6 +12,23 @@ node server/app.js
 
 Runs the app in the development mode.<br />
 Open [http://localhost:5000](http://localhost:5000) to view it in the browser.
+
+## Docker scripts
+
+The Docker container runs on port 5020 as default. You should map the host machines port to a port of your choosing. Below I have chosen to map to port 5020 on the host machine.
+( HostPort:DockerPort )
+
+```
+docker run -it -p 5020:5020 task-manager-backend
+```
+
+You can specify which port the docker container will run on by passing in an environmental variable when running the container, eg:
+
+```
+docker run -it -e PORT=<CHOSEN-PORT-NUMBER> -p 5020:<CHOSEN-PORT-NUMBER> task-manager-backend
+```
+
+Your Docker container will now be available at CHOSEN-PORT-NUMBER
 
 ## Frontend repository
 

--- a/server/app.js
+++ b/server/app.js
@@ -2,7 +2,7 @@ const express = require("express");
 const app = express();
 const cors = require("cors");
 const pool = require("./db");
-const port = 5000;
+const port = process.env.PORT || 5000;
 
 // Middleware
 app.use(cors());
@@ -15,7 +15,7 @@ app.get("", (req, res) => {
 // Create a task
 app.post("/tasks", async (req, res) => {
   try {
-    const { description } = req.body; 
+    const { description } = req.body;
     const newTask = await pool.query(
       "INSERT INTO task (description) VALUES($1) RETURNING *",
       [description]

--- a/server/app.js
+++ b/server/app.js
@@ -2,14 +2,14 @@ const express = require("express");
 const app = express();
 const cors = require("cors");
 const pool = require("./db");
-const port = process.env.PORT || 5000;
+const port = 5000;
 
 // Middleware
 app.use(cors());
 app.use(express.json());
 
 app.get("", (req, res) => {
-  res.send("Working - Backend!");
+  res.send("Working - Dockerised Backend!");
 });
 
 // Create a task
@@ -78,5 +78,5 @@ app.delete("/tasks/:id", async (req, res) => {
 });
 
 app.listen(port, () => {
-  console.log(`Node server is running on ${port}`);
+  console.log(`Node server is running on ${port} in Docker`);
 });

--- a/server/package.json
+++ b/server/package.json
@@ -4,12 +4,15 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "cors": "^2.8.5",
+    "pg": "^8.4.1"
   }
 }


### PR DESCRIPTION
# WHAT

Added ability to set the port of the dockerised Express instance, from the cli.
eg: docker run -it -e PORT=5021 -p 5020:5021 task-manager-backend

When the Express instance starts, it says  "Node server is running on 5021"

# WHY

Give us the ability to choose what port we want the Express instance to run on.